### PR TITLE
fix unnest subquery with asterisk in parent query

### DIFF
--- a/src/Interpreters/InterpreterSelectQuery.cpp
+++ b/src/Interpreters/InterpreterSelectQuery.cpp
@@ -310,14 +310,6 @@ InterpreterSelectQuery::InterpreterSelectQuery(
         ApplyWithSubqueryVisitor().visit(query_ptr);
     }
 
-    /// Daisy : starts. Try to eliminate subquery
-    if (settings.unnest_subqueries)
-    {
-        EliminateSubqueryVisitorData data;
-        EliminateSubqueryVisitor(data).visit(query_ptr);
-    }
-    /// Daisy : ends.
-
     JoinedTables joined_tables(getSubqueryContext(*context), getSelectQuery());
 
     bool got_storage_from_query = false;
@@ -485,6 +477,15 @@ InterpreterSelectQuery::InterpreterSelectQuery(
     };
 
     analyze(settings.optimize_move_to_prewhere);
+
+    /// Daisy : starts. Try to eliminate subquery
+    /// Put after "analyze" func call to use the rewrite result by "translateQualifiedNames" func call.
+    if (settings.unnest_subqueries)
+    {
+        EliminateSubqueryVisitorData data;
+        EliminateSubqueryVisitor(data).visit(query_ptr);
+    }
+    /// Daisy : ends.
 
     bool need_analyze_again = false;
     if (analysis_result.prewhere_constant_filter_description.always_false || analysis_result.prewhere_constant_filter_description.always_true)

--- a/src/Storages/StorageMergeTree.cpp
+++ b/src/Storages/StorageMergeTree.cpp
@@ -1539,7 +1539,7 @@ Int64 StorageMergeTree::loadSN() const
     auto buf = sn_file.second->readFile(sn_file.first);
     assertString("1\n", *buf);
 
-    Int64 sn = -1;;
+    Int64 sn = -1;
     DB::readText(sn, *buf);
     return sn;
 }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- New Feature
- Bug Fix
- Improvement
- Performance Improvement
- Backward Incompatible Change
- Build/Testing/Packaging Improvement
- Documentation (changelog entry is not required)
- Other
- Not for changelog (changelog entry is not required)


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

...


Detailed description / Documentation draft:

...

By adding documentation, you'll allow users to try your new feature immediately, not when someone else will have time to document it later. Documentation is necessary for all features that affect user experience in any way. You can add brief documentation draft above, or add documentation right into your patch as Markdown files in [docs](https://github.com/ClickHouse/ClickHouse/tree/master/docs) folder.

If you are doing this for the first time, it's recommended to read the lightweight [Contributing to ClickHouse Documentation](https://github.com/ClickHouse/ClickHouse/tree/master/docs/README.md) guide first.


Information about CI checks: https://clickhouse.tech/docs/en/development/continuous-integration/
