### PR TITLE
Fix issue DPT-3987 some ISO-8601 timestamp cannot be recoganized in r…

### DIFF
--- a/src/Server/RestRouterHandlers/IngestRawStoreHandler.cpp
+++ b/src/Server/RestRouterHandlers/IngestRawStoreHandler.cpp
@@ -90,6 +90,7 @@ String IngestRawStoreHandler::execute(ReadBuffer & input, HTTPServerResponse & /
     WriteBufferFromString out(dummy_string);
 
     query_context->setSetting("output_format_parallel_formatting", false);
+    query_context->setSetting("date_time_input_format", String{"best_effort"});
     executeQuery(*in, out, /* allow_into_outfile = */ false, query_context, {});
 
     Poco::JSON::Object resp;


### PR DESCRIPTION
…awstore ingest api, DPT-3986 RawStore Ingest API does not support ingore 'enrichment' fielsupport automatically extract ISO-8601 timestamp

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- New Feature
- Bug Fix
- Improvement
- Performance Improvement
- Backward Incompatible Change
- Build/Testing/Packaging Improvement
- Documentation (changelog entry is not required)
- Other
- Not for changelog (changelog entry is not required)


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

...


Detailed description / Documentation draft:

...

By adding documentation, you'll allow users to try your new feature immediately, not when someone else will have time to document it later. Documentation is necessary for all features that affect user experience in any way. You can add brief documentation draft above, or add documentation right into your patch as Markdown files in [docs](https://github.com/ClickHouse/ClickHouse/tree/master/docs) folder.

If you are doing this for the first time, it's recommended to read the lightweight [Contributing to ClickHouse Documentation](https://github.com/ClickHouse/ClickHouse/tree/master/docs/README.md) guide first.


Information about CI checks: https://clickhouse.tech/docs/en/development/continuous-integration/
