### PR TITLE
Fix issue DPT-3137 by get metadata_snapshot from the Replicated* tabl…

### DIFF
--- a/src/Interpreters/InterpreterSelectQuery.cpp
+++ b/src/Interpreters/InterpreterSelectQuery.cpp
@@ -322,8 +322,25 @@ InterpreterSelectQuery::InterpreterSelectQuery(
     {
         table_lock = storage->lockForShare(context->getInitialQueryId(), context->getSettingsRef().lock_acquire_timeout);
         table_id = storage->getStorageID();
+        /// Daisy : starts
         if (!metadata_snapshot)
-            metadata_snapshot = storage->getInMemoryMetadataPtr();
+        {
+            if (storage->getName() != "Distributed")
+            {
+                metadata_snapshot = storage->getInMemoryMetadataPtr();
+            }
+            else
+            {
+                const StorageDistributed * storage_distributed = static_cast<const StorageDistributed *>(storage.get());
+                StoragePtr storage_replicated = DatabaseCatalog::instance().getTable(
+                    StorageID(storage_distributed->getRemoteDatabaseName(), storage_distributed->getRemoteTableName()), context);
+                if (storage_replicated)
+                    metadata_snapshot = storage_replicated->getInMemoryMetadataPtr();
+                else
+                    metadata_snapshot = storage->getInMemoryMetadataPtr();
+            }
+        }
+        /// Daisy : ends
     }
 
     if (has_input || !joined_tables.resolveTables())


### PR DESCRIPTION
…e instead of Distributed table

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

**Changelog category (leave one):**
- Bug Fix


**Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):**

...


**Detailed description / Documentation draft:**

Fix issue DPT-3137 by get metadata_snapshot from the Replicated* table instead of Distributed table


By adding documentation, you'll allow users to try your new feature immediately, not when someone else will have time to document it later. Documentation is necessary for all features that affect user experience in any way. You can add brief documentation draft above, or add documentation right into your patch as Markdown files in [docs](https://github.com/ClickHouse/ClickHouse/tree/master/docs) folder.

If you are doing this for the first time, it's recommended to read the lightweight [Contributing to ClickHouse Documentation](https://github.com/ClickHouse/ClickHouse/tree/master/docs/README.md) guide first.


Information about CI checks: https://clickhouse.tech/docs/en/development/continuous-integration/
