### PR TITLE
fix bug of parent_selectitem_not_in_subquery_selects

### DIFF
--- a/src/Interpreters/UnnestSubqueryVisitor.cpp
+++ b/src/Interpreters/UnnestSubqueryVisitor.cpp
@@ -177,7 +177,7 @@ bool UnnestSubqueryVisitorData::mergeable(
     return true;
 }
 
-bool UnnestSubqueryVisitorData::isValid(const ASTPtr & ast, const std::unordered_map<String, ASTPtr> & subquery_selects_map)
+bool UnnestSubqueryVisitorData::isValid(const ASTPtr & ast, const std::unordered_map<String, ASTPtr> & subquery_selects_map) const
 {
     if (ast->as<ASTAsterisk>() || ast->as<ASTQualifiedAsterisk>())
     {

--- a/src/Interpreters/UnnestSubqueryVisitor.cpp
+++ b/src/Interpreters/UnnestSubqueryVisitor.cpp
@@ -65,7 +65,7 @@ void UnnestSubqueryVisitorData::visit(ASTTableExpression & table, ASTSelectQuery
     ASTs subquery_selects;
     subquery_selects_map.reserve(sub_query->size());
     subquery_selects.reserve(sub_query->size());
-    if (!mergeable(*sub_query, asterisk_in_subquery, subquery_selects_map, subquery_selects))
+    if (!mergeable(*sub_query, parent_select.select()->children, asterisk_in_subquery, subquery_selects_map, subquery_selects))
     {
         return;
     }
@@ -131,6 +131,7 @@ void UnnestSubqueryVisitorData::rewriteColumn(
 
 bool UnnestSubqueryVisitorData::mergeable(
     const ASTSelectQuery & child_query,
+    const ASTs & parent_selects,
     bool & asterisk_in_subquery,
     std::unordered_map<String, ASTPtr> & subquery_selects_map,
     ASTs & subquery_selects)
@@ -161,6 +162,45 @@ bool UnnestSubqueryVisitorData::mergeable(
             return false;
         }
     }
+
+    if (!asterisk_in_subquery)
+    {
+        for (const auto & parent_select_item : parent_selects)
+        {
+            if (!isValid(parent_select_item, subquery_selects_map))
+            {
+                return false;
+            }
+        }
+    }
+
+    return true;
+}
+
+bool UnnestSubqueryVisitorData::isValid(const ASTPtr & ast, const std::unordered_map<String, ASTPtr> & subquery_selects_map)
+{
+    if (ast->as<ASTAsterisk>() || ast->as<ASTQualifiedAsterisk>())
+    {
+        return true;
+    }
+
+    if (auto * identifier = ast->as<ASTIdentifier>())
+    {
+        const String & column_name = identifier->getColumnName();
+        if (subquery_selects_map.find(column_name) == subquery_selects_map.end())
+        {
+            return false;
+        }
+    }
+
+    for (auto & child : ast->children)
+    {
+        if (!isValid(child, subquery_selects_map))
+        {
+            return false;
+        }
+    }
+
     return true;
 }
 

--- a/src/Interpreters/UnnestSubqueryVisitor.h
+++ b/src/Interpreters/UnnestSubqueryVisitor.h
@@ -28,9 +28,11 @@ private:
         const ASTs & subquery_selects);
     bool mergeable(
         const ASTSelectQuery & child_query,
+        const ASTs & parent_selects,
         bool & asterisk_in_subquery,
         std::unordered_map<String, ASTPtr> & subquery_selects_map,
         ASTs & subquery_selects);
+    bool isValid(const ASTPtr & ast, const std::unordered_map<String, ASTPtr> & subquery_selects_map);
 };
 
 using UnnestSubqueryVisitor = UnnestSubqueryVisitorData::Visitor;

--- a/src/Interpreters/UnnestSubqueryVisitor.h
+++ b/src/Interpreters/UnnestSubqueryVisitor.h
@@ -32,7 +32,7 @@ private:
         bool & asterisk_in_subquery,
         std::unordered_map<String, ASTPtr> & subquery_selects_map,
         ASTs & subquery_selects);
-    bool isValid(const ASTPtr & ast, const std::unordered_map<String, ASTPtr> & subquery_selects_map);
+    bool isValid(const ASTPtr & ast, const std::unordered_map<String, ASTPtr> & subquery_selects_map) const;
 };
 
 using UnnestSubqueryVisitor = UnnestSubqueryVisitorData::Visitor;

--- a/src/Interpreters/tests/gtest_eliminate_subquery.cpp
+++ b/src/Interpreters/tests/gtest_eliminate_subquery.cpp
@@ -91,8 +91,8 @@ TEST(EliminateSubquery, OptimizedQuery)
         "SELECT count(b.code) FROM product_info AS a , product_info AS b WHERE a.productid = b.productid");
     EXPECT_EQ(
         optimizeSubquery(
-            "SELECT count(code) FROM (SELECT a.code, b.code FROM product_info a, product_info b WHERE (a.productid = b.productid))"),
-        "SELECT count(code) FROM product_info AS a , product_info AS b WHERE a.productid = b.productid");
+            "SELECT count(a.code) FROM (SELECT a.code, b.code FROM product_info a, product_info b WHERE (a.productid = b.productid))"),
+        "SELECT count(a.code) FROM product_info AS a , product_info AS b WHERE a.productid = b.productid");
     EXPECT_EQ(
         optimizeSubquery("SELECT * FROM (SELECT _raw AS c, t._raw FROM default.frontier_integration_test AS t)"),
         "SELECT _raw AS c, t._raw FROM default.frontier_integration_test AS t");
@@ -188,4 +188,10 @@ TEST(EliminateSubquery, FailedOptimizedQuery)
         optimizeSubquery(
             "SELECT count(t.code) FROM (SELECT code, code FROM product_info a , product_info b WHERE a.productid = b.productid) AS t"),
         "SELECT count(t.code) FROM (SELECT code, code FROM product_info AS a , product_info AS b WHERE a.productid = b.productid) AS t");
+    EXPECT_EQ(optimizeSubquery("SELECT _time FROM (SELECT name FROM price)"), "SELECT _time FROM (SELECT name FROM price)");
+    EXPECT_EQ(
+        optimizeSubquery(
+            "SELECT count(code) FROM (SELECT a.code, b.code FROM product_info a, product_info b WHERE a.productid = b.productid)"),
+        "SELECT count(code) FROM (SELECT a.code, b.code FROM product_info AS a , product_info AS b WHERE a.productid = b.productid)");
+    EXPECT_EQ(optimizeSubquery("SELECT b FROM (SELECT b AS a FROM product)"), "SELECT b FROM (SELECT b AS a FROM product)");
 }


### PR DESCRIPTION
PR checklist:
- Did you run ClangFormat ?
- Did you run CheckStyle ?
- Did you check the comment / log / exception conventions in Engineering code process wiki page ?
- Did you import unncessary headers ?
- Did you surround `Daisy : starts/ends` for new code in existing ClickHouse code base ?

Please write user-readable short description of the changes:
