### PR TITLE
refactor Ingest status handler

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,7 +2,7 @@ PR checklist:
 - Did you run ClangFormat ?
 - Did you run CheckStyle ?
 - Did you check the comment / log / exception conventions in Engineering code process wiki page ?
-- Did you import unncessary headers ?
+- Did you import unnecessary headers ?
 - Did you surround `Daisy : starts/ends` for new code in existing ClickHouse code base ?
 
 Please write user-readable short description of the changes:

--- a/README.md
+++ b/README.md
@@ -212,4 +212,6 @@ $ curl http://localhost:8123/dae/v1/ingest/tables/testtable -X POST -H "content-
 ## Query Data
 
 ### Query Data via REST API
+```
 $ curl http://localhost:8123/dae/v1/search -X POST -H "content-type: application/json" -d '{"query": "SELECT * FROM testtable"}'
+```

--- a/src/DistributedMetadata/CatalogService.h
+++ b/src/DistributedMetadata/CatalogService.h
@@ -80,6 +80,7 @@ public:
 
     std::vector<NodePtr> nodes(const String & role = "") const;
     NodePtr nodeByIdentity(const String & identity) const;
+    NodePtr nodeByChannel(const String & channel) const;
 
 private:
     bool setTableStorageByName(const String & database, const String & table, const StoragePtr & storage);

--- a/src/DistributedMetadata/PlacementService.cpp
+++ b/src/DistributedMetadata/PlacementService.cpp
@@ -122,21 +122,6 @@ std::vector<NodeMetricsPtr> PlacementService::nodes() const
     return nodes;
 }
 
-String PlacementService::getNodeIdentityByChannel(const String & channel) const
-{
-    std::shared_lock guard(rwlock);
-
-    for (const auto & [node_identity, node_metrics] : nodes_metrics)
-    {
-        if (!node_metrics->staled && node_metrics->node.channel == channel)
-        {
-            return node_metrics->node.host;
-        }
-    }
-
-    return "";
-}
-
 void PlacementService::preShutdown()
 {
     if (broadcast_task)

--- a/src/DistributedMetadata/sendRequest.cpp
+++ b/src/DistributedMetadata/sendRequest.cpp
@@ -35,7 +35,7 @@ std::pair<String, Int32> sendRequest(
     Poco::Logger * log)
 {
     /// One second for connect/send/receive
-    ConnectionTimeouts timeouts({1, 0}, {1, 0}, {5, 0});
+    ConnectionTimeouts timeouts({2, 0}, {5, 0}, {10, 0});
 
     PooledHTTPSessionPtr session;
     try
@@ -45,7 +45,8 @@ std::pair<String, Int32> sendRequest(
         request.setHost(uri.getHost());
         request.setContentLength(payload.size());
         request.setContentType("application/json");
-        request.add("X-ClickHouse-Query-Id", query_id);
+        /// FIXME : query ID chain. Change the query ID to avoid same query ID issue
+        request.add("X-ClickHouse-Query-Id", "from-" + query_id);
         request.add("X-ClickHouse-User", user);
 
         if (!password.empty())

--- a/src/DistributedWriteAheadLog/DistributedWriteAheadLogPool.cpp
+++ b/src/DistributedWriteAheadLog/DistributedWriteAheadLogPool.cpp
@@ -72,11 +72,6 @@ void DistributedWriteAheadLogPool::startup()
 
 void DistributedWriteAheadLogPool::shutdown()
 {
-    if (!global_context->isDistributed())
-    {
-        return;
-    }
-
     if (stopped.test_and_set())
     {
         return;

--- a/src/Server/RestRouterHandlers/ClusterInfoHandler.cpp
+++ b/src/Server/RestRouterHandlers/ClusterInfoHandler.cpp
@@ -61,7 +61,7 @@ std::pair<String, Int32> ClusterInfoHandler::executeGet(const Poco::JSON::Object
         return {response, http_status};
     }
 
-    return {buildErrorResponse(response), http_status};
+    return {jsonErrorResponseFrom(response), http_status};
 }
 
 String ClusterInfoHandler::buildResponse() const
@@ -76,19 +76,10 @@ String ClusterInfoHandler::buildResponse() const
 
     Poco::JSON::Object resp;
     resp.set("nodes", json_nodes);
+    resp.set("request_id", query_context->getCurrentQueryId());
 
     std::stringstream resp_str_stream; /// STYLE_CHECK_ALLOW_STD_STRING_STREAM
     resp.stringify(resp_str_stream, 0);
     return resp_str_stream.str();
-}
-
-String ClusterInfoHandler::buildErrorResponse(const String & response) const
-{
-    if (response.find("request_id") != String::npos && response.find("error_msg") != String::npos)
-    {
-        /// It is already a well-formed response from remote
-        return response;
-    }
-    return jsonErrorResponse("Internal server error", ErrorCodes::RESOURCE_NOT_INITED);
 }
 }

--- a/src/Server/RestRouterHandlers/ClusterInfoHandler.h
+++ b/src/Server/RestRouterHandlers/ClusterInfoHandler.h
@@ -13,6 +13,5 @@ public:
 private:
     std::pair<String, Int32> executeGet(const Poco::JSON::Object::Ptr & payload) const override;
     String buildResponse() const;
-    String buildErrorResponse(const String & response) const;
 };
 }

--- a/src/Server/RestRouterHandlers/IngestStatusHandler.cpp
+++ b/src/Server/RestRouterHandlers/IngestStatusHandler.cpp
@@ -1,15 +1,16 @@
 #include "IngestStatusHandler.h"
 #include "SchemaValidator.h"
 
-#include <DistributedMetadata/PlacementService.h>
-#include <IO/HTTPCommon.h>
+#include <DistributedMetadata/CatalogService.h>
+#include <DistributedMetadata/sendRequest.h>
 #include <Storages/StorageDistributedMergeTree.h>
 
-#include <Poco/Net/HTTPRequest.h>
+/// #include <Poco/Net/HTTPRequest.h>
+/// #include <Poco/Net/HTTPResponse.h>
 #include <Poco/Path.h>
 
 #include <numeric>
-#include <vector>
+/// #include <vector>
 
 namespace DB
 {
@@ -33,9 +34,6 @@ const std::map<String, std::map<String, String>> POLL_SCHEMA = {{"required", {{"
 StoragePtr
 getTableStorage(const String & database_name, const String & table_name, ContextPtr query_context, String & error, int & error_code)
 {
-    error.clear();
-    error_code = ErrorCodes::OK;
-
     StoragePtr storage;
     try
     {
@@ -64,7 +62,7 @@ getTableStorage(const String & database_name, const String & table_name, Context
     return storage;
 }
 
-String makeBatchResponse(const std::vector<IngestingBlocks::IngestStatus> & statuses)
+String makeBatchResponse(const std::vector<IngestingBlocks::IngestStatus> & statuses, const String & query_id)
 {
     Poco::JSON::Object resp;
     Poco::JSON::Array json_statuses;
@@ -77,6 +75,7 @@ String makeBatchResponse(const std::vector<IngestingBlocks::IngestStatus> & stat
         json_statuses.add(json);
     }
     resp.set("status", json_statuses);
+    resp.set("request_id", query_id);
     std::stringstream resp_str_stream; /// STYLE_CHECK_ALLOW_STD_STRING_STREAM
     resp.stringify(resp_str_stream, 0);
     return resp_str_stream.str();
@@ -114,22 +113,16 @@ bool IngestStatusHandler::categorizePollIds(const std::vector<String> & poll_ids
 
 std::pair<String, Int32> IngestStatusHandler::executePost(const Poco::JSON::Object::Ptr & payload) const
 {
-    String error;
-    PlacementService & placement = PlacementService::instance(query_context);
-    const String & target_node = placement.getNodeIdentityByChannel(payload->get("channel").toString());
+    if (!payload)
+        return {jsonErrorResponse("payload is empty", ErrorCodes::INCORRECT_DATA), HTTPResponse::HTTP_BAD_REQUEST};
 
-    if (target_node.empty())
+    const auto & chan = payload->get("channel").toString();
+    if (query_context->getChannel() == chan)
     {
-        /// Invalid node
-        return {jsonErrorResponse("Unknown channel", ErrorCodes::CHANNEL_ID_NOT_EXISTS), HTTPResponse::HTTP_NOT_FOUND};
-    }
-
-    if (target_node == query_context->getNodeIdentity())
-    {
-        const auto & arr = payload->getArray("poll_ids");
+        String error;
+        /// The current node is the target ingesting node having the channel
         std::vector<String> poll_ids;
-
-        for (const auto & poll_id : *arr)
+        for (const auto & poll_id : *payload->getArray("poll_ids"))
             poll_ids.emplace_back(poll_id.extract<String>());
 
         TablePollIdMap table_poll_ids;
@@ -139,10 +132,9 @@ std::pair<String, Int32> IngestStatusHandler::executePost(const Poco::JSON::Obje
         }
 
         std::vector<IngestingBlocks::IngestStatus> statuses;
-        int error_code = ErrorCodes::OK;
-
         for (const auto & table_polls : table_poll_ids)
         {
+            int error_code = ErrorCodes::OK;
             auto storage = getTableStorage(table_polls.first.first, table_polls.first.second, query_context, error, error_code);
             if (!storage)
             {
@@ -150,7 +142,7 @@ std::pair<String, Int32> IngestStatusHandler::executePost(const Poco::JSON::Obje
                     log,
                     "{}, for poll_ids: {}",
                     error,
-                    std::accumulate(table_polls.second.begin(), table_polls.second.end(), std::string{","}),
+                    std::accumulate(table_polls.second.begin(), table_polls.second.end(), std::string(",")),
                     error_code);
                 continue;
             }
@@ -161,78 +153,39 @@ std::pair<String, Int32> IngestStatusHandler::executePost(const Poco::JSON::Obje
 
         if (statuses.empty())
         {
-            return {
-                jsonErrorResponse("None of poll_id in 'poll_ids' is valid", ErrorCodes::INVALID_POLL_ID), HTTPResponse::HTTP_BAD_REQUEST};
+            return {jsonErrorResponse("'poll_ids' are all invalid", ErrorCodes::INVALID_POLL_ID), HTTPResponse::HTTP_BAD_REQUEST};
         }
-        return {makeBatchResponse(statuses), HTTPResponse::HTTP_OK};
+        return {makeBatchResponse(statuses, query_context->getCurrentQueryId()), HTTPResponse::HTTP_OK};
     }
     else
     {
-        Poco::URI uri{fmt::format(BATCH_URL, target_node, query_context->getConfigRef().getString("http_port"))};
-        return forwardRequest(uri, payload);
-    }
-}
+        auto target_node = CatalogService::instance(query_context).nodeByChannel(chan);
+        if (target_node == nullptr)
+        {
+            /// Node not found, either node is gone or invalid channel
+            return {jsonErrorResponse("Unknown channel", ErrorCodes::CHANNEL_ID_NOT_EXISTS), HTTPResponse::HTTP_NOT_FOUND};
+        }
 
-std::pair<String, Int32> IngestStatusHandler::forwardRequest(const Poco::URI & uri, const Poco::JSON::Object::Ptr & payload) const
-{
-    LOG_DEBUG(log, "Forward request to uri={}", uri.toString());
-
-    /// One second for connect/send/receive
-    ConnectionTimeouts timeouts({1, 0}, {1, 0}, {5, 0});
-
-    String error;
-    PooledHTTPSessionPtr session;
-    try
-    {
-        if (!payload)
-            return {jsonErrorResponse("payload is empty", ErrorCodes::INCORRECT_DATA), HTTPResponse::HTTP_BAD_REQUEST};
-
-        session = makePooledHTTPSession(uri, timeouts, 1);
-        Poco::Net::HTTPRequest request{Poco::Net::HTTPRequest::HTTP_GET, uri.getPathAndQuery(), Poco::Net::HTTPRequest::HTTP_1_1};
-        request.setHost(uri.getHost());
         std::stringstream req_body_stream; /// STYLE_CHECK_ALLOW_STD_STRING_STREAM
         payload->stringify(req_body_stream, 0);
-        request.setMethod(Poco::Net::HTTPRequest::HTTP_POST);
         const String & body = req_body_stream.str();
-        request.setContentType("application/json");
-        request.setContentLength(body.length());
-        request.add("X-ClickHouse-Query-Id", query_context->getCurrentQueryId());
-        auto & ostr = session->sendRequest(request);
-        ostr << req_body_stream.str();
 
-        if (!ostr.good())
+        /// Forward the request to target node
+        /// FIXME, https
+        Poco::URI uri{fmt::format(BATCH_URL, target_node->host, target_node->http_port)};
+        auto [response, http_status] = sendRequest(
+            uri,
+            HTTPRequest::HTTP_POST,
+            query_context->getCurrentQueryId(),
+            query_context->getUserName(),
+            query_context->getPasswordByUserName(query_context->getUserName()),
+            body,
+            log);
+        if (http_status == HTTPResponse::HTTP_OK)
         {
-            error = "Failed on uri=" + uri.toString();
-            LOG_ERROR(log, error);
-            return {jsonErrorResponse(error, ErrorCodes::SEND_POLL_REQ_ERROR), HTTPResponse::HTTP_SERVICE_UNAVAILABLE};
+            return {response, http_status};
         }
-
-        Poco::Net::HTTPResponse response;
-        auto & istr = session->receiveResponse(response);
-        auto http_status = response.getStatus();
-
-        if (http_status != Poco::Net::HTTPResponse::HTTP_OK)
-        {
-            LOG_INFO(log, "Executed on uri={} failed", uri.toString());
-        }
-        return {String(std::istreambuf_iterator<char>(istr), {}), http_status};
+        return {jsonErrorResponseFrom(response, ErrorCodes::SEND_POLL_REQ_ERROR), http_status};
     }
-    catch (const Poco::Exception & e)
-    {
-        if (!session.isNull())
-        {
-            session->attachSessionData(e.message());
-        }
-        error = "Failed on uri=" + uri.toString() + " error=" + e.message() + " exception=" + getCurrentExceptionMessage(false, true);
-        LOG_ERROR(log, error);
-    }
-    catch (...)
-    {
-        error = "Failed on uri=" + uri.toString() + " exception=" + getCurrentExceptionMessage(false, true);
-        LOG_ERROR(log, error);
-    }
-
-    return {jsonErrorResponse(error, ErrorCodes::SEND_POLL_REQ_ERROR), HTTPResponse::HTTP_INTERNAL_SERVER_ERROR};
 }
-
 }

--- a/src/Server/RestRouterHandlers/IngestStatusHandler.cpp
+++ b/src/Server/RestRouterHandlers/IngestStatusHandler.cpp
@@ -5,12 +5,9 @@
 #include <DistributedMetadata/sendRequest.h>
 #include <Storages/StorageDistributedMergeTree.h>
 
-/// #include <Poco/Net/HTTPRequest.h>
-/// #include <Poco/Net/HTTPResponse.h>
 #include <Poco/Path.h>
 
 #include <numeric>
-/// #include <vector>
 
 namespace DB
 {
@@ -142,7 +139,7 @@ std::pair<String, Int32> IngestStatusHandler::executePost(const Poco::JSON::Obje
                     log,
                     "{}, for poll_ids: {}",
                     error,
-                    std::accumulate(table_polls.second.begin(), table_polls.second.end(), std::string(",")),
+                    std::accumulate(table_polls.second.begin(), table_polls.second.end(), std::string{","}),
                     error_code);
                 continue;
             }

--- a/src/Server/RestRouterHandlers/IngestStatusHandler.h
+++ b/src/Server/RestRouterHandlers/IngestStatusHandler.h
@@ -18,7 +18,6 @@ private:
     bool validatePost(const Poco::JSON::Object::Ptr & payload, String & error_msg) const override;
     bool streamingInput() const override { return false; }
 
-    std::pair<String, Int32> forwardRequest(const Poco::URI & uri, const Poco::JSON::Object::Ptr & payload) const;
     bool categorizePollIds(const std::vector<String> & poll_ids, TablePollIdMap & table_poll_ids, String & error) const;
 };
 }

--- a/src/Server/RestRouterHandlers/RestRouterHandler.cpp
+++ b/src/Server/RestRouterHandlers/RestRouterHandler.cpp
@@ -56,7 +56,7 @@ void RestRouterHandler::execute(HTTPServerRequest & request, HTTPServerResponse 
     if (!streamingOutput())
     {
         response.setStatusAndReason(HTTPResponse::HTTPStatus(result.second));
-        *response.send() << result.first << std::endl;
+        *response.send() << result.first;
     }
 }
 

--- a/src/Server/RestRouterHandlers/RestRouterHandler.h
+++ b/src/Server/RestRouterHandlers/RestRouterHandler.h
@@ -21,6 +21,7 @@ namespace ErrorCodes
 {
     extern const int BAD_REQUEST_PARAMETER;
     extern const int UNKNOWN_TYPE_OF_QUERY;
+    extern const int UNKNOWN_EXCEPTION;
 }
 
 class RestRouterHandler : private boost::noncopyable
@@ -103,6 +104,17 @@ protected:
     String jsonErrorResponse(const String & error_msg, int error_code) const
     {
         return jsonErrorResponse(error_msg, error_code, query_context->getCurrentQueryId());
+    }
+
+    /// Compose the error response from a response of a forwared request
+    String jsonErrorResponseFrom(const String & response, int error_code = ErrorCodes::UNKNOWN_EXCEPTION) const
+    {
+        if (response.find("request_id") != String::npos && response.find("error_msg") != String::npos)
+        {
+            /// It is already a well-formed response in JSON from remote
+            return response;
+        }
+        return jsonErrorResponse("Internal server error", error_code);
     }
 
 private:


### PR DESCRIPTION
PR checklist:
- Did you run ClangFormat ? Yes
- Did you run CheckStyle ? Yes
- Did you check the comment / log / exception conventions in Engineering code process wiki page ? Yes
- Did you import unncessary headers ? No
- Did you surround `Daisy : starts/ends` for new code in existing ClickHouse code base ? Yes

Please write user-readable short description of the changes:
1. Refactor Ingest status handler and fix the implementation issues like using placement service to discover target channel. Placement service is not running on every node which is not appropriate for this discovery purpose.
2. Fix DWAL pool shutdown issue. There is reset after use during program shutdown 
3. Fix query ID forwarding issue
4. Other small refactoring

* fix shutdown exception because global context is already reset