### PR TITLE
Fix tasks service request forwarding and some refactoring

### DIFF
--- a/src/DistributedMetadata/MetadataService.h
+++ b/src/DistributedMetadata/MetadataService.h
@@ -22,6 +22,8 @@ public:
     void startup();
     void shutdown();
 
+    const String & nodeRoles() const { return node_roles; }
+
 private:
     void tailingRecords();
     void doTailingRecords();

--- a/src/DistributedMetadata/TaskStatusService.cpp
+++ b/src/DistributedMetadata/TaskStatusService.cpp
@@ -465,6 +465,7 @@ bool TaskStatusService::createTaskTable()
     {
         return true;
     }
+
     if (!create_task_table_id.empty())
     {
         auto task = findByIdInMemory(create_task_table_id);

--- a/src/Server/RestRouterHandlers/ClusterInfoHandler.cpp
+++ b/src/Server/RestRouterHandlers/ClusterInfoHandler.cpp
@@ -31,7 +31,7 @@ std::pair<String, Int32> ClusterInfoHandler::executeGet(const Poco::JSON::Object
         {
             /// If the current node is one of the placement nodes
             /// Use the current node to serve the request directly
-            return {buildResponse(), HTTPResponse::HTTP_OK};
+            return {getClusterInfoLocally(), HTTPResponse::HTTP_OK};
         }
     }
 
@@ -64,7 +64,7 @@ std::pair<String, Int32> ClusterInfoHandler::executeGet(const Poco::JSON::Object
     return {jsonErrorResponseFrom(response), http_status};
 }
 
-String ClusterInfoHandler::buildResponse() const
+String ClusterInfoHandler::getClusterInfoLocally() const
 {
     auto nodes{PlacementService::instance(query_context).nodes()};
 

--- a/src/Server/RestRouterHandlers/ClusterInfoHandler.h
+++ b/src/Server/RestRouterHandlers/ClusterInfoHandler.h
@@ -12,6 +12,6 @@ public:
 
 private:
     std::pair<String, Int32> executeGet(const Poco::JSON::Object::Ptr & payload) const override;
-    String buildResponse() const;
+    String getClusterInfoLocally() const;
 };
 }

--- a/src/Server/RestRouterHandlers/ColumnDefinition.cpp
+++ b/src/Server/RestRouterHandlers/ColumnDefinition.cpp
@@ -13,7 +13,7 @@ namespace
     String buildResponse(const String & query_id)
     {
         Poco::JSON::Object resp;
-        resp.set("query_id", query_id);
+        resp.set("request_id", query_id);
         std::stringstream resp_str_stream; /// STYLE_CHECK_ALLOW_STD_STRING_STREAM
         resp.stringify(resp_str_stream, 0);
 

--- a/src/Server/RestRouterHandlers/DatabaseRestRouterHandler.cpp
+++ b/src/Server/RestRouterHandlers/DatabaseRestRouterHandler.cpp
@@ -70,7 +70,7 @@ std::pair<String, Int32> DatabaseRestRouterHandler::processQuery(const String & 
     }
     io.onFinish();
 
-    resp.set("query_id", query_context->getCurrentQueryId());
+    resp.set("request_id", query_context->getCurrentQueryId());
     std::stringstream resp_str_stream; /// STYLE_CHECK_ALLOW_STD_STRING_STREAM
     resp.stringify(resp_str_stream, 0);
 

--- a/src/Server/RestRouterHandlers/IngestRawStoreHandler.cpp
+++ b/src/Server/RestRouterHandlers/IngestRawStoreHandler.cpp
@@ -98,7 +98,7 @@ std::pair<String, Int32> IngestRawStoreHandler::execute(ReadBuffer & input) cons
     executeQuery(*in, out, /* allow_into_outfile = */ false, query_context, {});
 
     Poco::JSON::Object resp;
-    resp.set("query_id", query_context->getClientInfo().current_query_id);
+    resp.set("request_id", query_context->getCurrentQueryId());
     const auto & poll_id = query_context->getQueryStatusPollId();
     if (!poll_id.empty())
     {

--- a/src/Server/RestRouterHandlers/IngestRestRouterHandler.cpp
+++ b/src/Server/RestRouterHandlers/IngestRestRouterHandler.cpp
@@ -91,7 +91,7 @@ std::pair<String, Int32> IngestRestRouterHandler::execute(ReadBuffer & input) co
 
     /// Send back ingest response
     Poco::JSON::Object resp;
-    resp.set("query_id", query_context->getCurrentQueryId());
+    resp.set("request_id", query_context->getCurrentQueryId());
     const auto & poll_id = query_context->getQueryStatusPollId();
     if (!poll_id.empty())
     {

--- a/src/Server/RestRouterHandlers/IngestStatusHandler.h
+++ b/src/Server/RestRouterHandlers/IngestStatusHandler.h
@@ -19,5 +19,6 @@ private:
     bool streamingInput() const override { return false; }
 
     bool categorizePollIds(const std::vector<String> & poll_ids, TablePollIdMap & table_poll_ids, String & error) const;
+    std::pair<String, Int32> getIngestStatusLocally(const Poco::JSON::Object::Ptr & payload) const;
 };
 }

--- a/src/Server/RestRouterHandlers/TableRestRouterHandler.cpp
+++ b/src/Server/RestRouterHandlers/TableRestRouterHandler.cpp
@@ -92,7 +92,7 @@ std::pair<String, Int32> TableRestRouterHandler::executeGet(const Poco::JSON::Ob
     Poco::JSON::Object resp;
     buildTablesJSON(resp, tables);
 
-    resp.set("query_id", query_context->getCurrentQueryId());
+    resp.set("request_id", query_context->getCurrentQueryId());
     std::stringstream resp_str_stream; /// STYLE_CHECK_ALLOW_STD_STRING_STREAM
     resp.stringify(resp_str_stream, 0);
     String resp_str = resp_str_stream.str();

--- a/src/Server/RestRouterHandlers/TaskRestRouterHandler.h
+++ b/src/Server/RestRouterHandlers/TaskRestRouterHandler.h
@@ -2,8 +2,6 @@
 
 #include "RestRouterHandler.h"
 
-#include <DistributedMetadata/TaskStatusService.h>
-
 namespace DB
 {
 class TaskRestRouterHandler final : public RestRouterHandler
@@ -14,6 +12,7 @@ public:
 
 private:
     std::pair<String, Int32> executeGet(const Poco::JSON::Object::Ptr & payload) const override;
+    std::pair<String, Int32> getTasksLocally() const;
 };
 
 }


### PR DESCRIPTION
PR checklist:
- Did you run ClangFormat ? Yes
- Did you run CheckStyle ? Yes
- Did you check the comment / log / exception conventions in Engineering code process wiki page ? Yes
- Did you import unnecessary headers ? No
- Did you surround `Daisy : starts/ends` for new code in existing ClickHouse code base ? Yes

Please write user-readable short description of the changes:
Fix Task service request forwarding, make qurey_id and request_id in response consistent to use `request_id` and some refactoring
