### PR TITLE
don't dump empty sn file after block merge

### DIFF
--- a/src/Storages/MergeTree/MergedBlockOutputStream.cpp
+++ b/src/Storages/MergeTree/MergedBlockOutputStream.cpp
@@ -200,7 +200,7 @@ void MergedBlockOutputStream::finalizePartOnDisk(
     }
 
     /// Daisy : starts
-    if (new_part->seq_info)
+    if (new_part->seq_info && new_part->seq_info->valid())
     {
         auto out = volume->getDisk()->writeFile(part_path + "sn.txt", 4096);
         new_part->seq_info->write(*out);


### PR DESCRIPTION
PR checklist:
- Did you run ClangFormat ? Yes
- Did you run CheckStyle ? Yes
- Did you check the comment / log / exception conventions in Engineering code process wiki page ? Yes
- Did you import unnecessary headers ? No
- Did you surround `Daisy : starts/ends` for new code in existing ClickHouse code base ? Yes

Please write user-readable short description of the changes:
Avoid writing empty sn file if after block merge sn becomes empty