### PR TITLE
Correct the way that SQLAnalalyze api used to determine 'has_aggr'. I…

### DIFF
--- a/src/Interpreters/IInterpreterUnionOrSelectQuery.h
+++ b/src/Interpreters/IInterpreterUnionOrSelectQuery.h
@@ -28,6 +28,10 @@ public:
 
     size_t getMaxStreams() const { return max_streams; }
 
+    /// Daisy : starts
+    virtual bool hasAggregation() const = 0;
+    /// Daisy : ends
+
     void extendQueryLogElemImpl(QueryLogElement & elem, const ASTPtr &, ContextPtr) const override;
 
 protected:

--- a/src/Interpreters/InterpreterSelectQuery.h
+++ b/src/Interpreters/InterpreterSelectQuery.h
@@ -97,7 +97,9 @@ public:
 
     const Names & getRequiredColumns() const { return required_columns; }
 
-    bool hasAggregation() const { return query_analyzer->hasAggregation(); }
+    /// Daisy : starts
+    bool hasAggregation() const override { return query_analyzer->hasAggregation(); }
+    /// Daisy : ends
 
     static void addEmptySourceToQueryPlan(
         QueryPlan & query_plan, const Block & source_header, const SelectQueryInfo & query_info, ContextPtr context_);

--- a/src/Interpreters/InterpreterSelectWithUnionQuery.cpp
+++ b/src/Interpreters/InterpreterSelectWithUnionQuery.cpp
@@ -231,6 +231,17 @@ Block InterpreterSelectWithUnionQuery::getSampleBlock(const ASTPtr & query_ptr_,
         return cache[key] = InterpreterSelectWithUnionQuery(query_ptr_, context_, SelectQueryOptions().analyze()).getSampleBlock();
 }
 
+/// Daisy : starts
+bool InterpreterSelectWithUnionQuery::hasAggregation() const
+{
+    for (auto & interpreter : nested_interpreters)
+    {
+        if (interpreter->hasAggregation())
+            return true;
+    }
+    return false;
+}
+/// Daisy : ends
 
 void InterpreterSelectWithUnionQuery::buildQueryPlan(QueryPlan & query_plan)
 {

--- a/src/Interpreters/InterpreterSelectWithUnionQuery.h
+++ b/src/Interpreters/InterpreterSelectWithUnionQuery.h
@@ -37,6 +37,10 @@ public:
         ContextPtr context_,
         bool is_subquery = false);
 
+    /// Daisy : starts
+    bool hasAggregation() const override;
+    /// Daisy : ends
+
     virtual void ignoreWithTotals() override;
 
 private:

--- a/src/Interpreters/QueryProfileVisitor.cpp
+++ b/src/Interpreters/QueryProfileVisitor.cpp
@@ -29,14 +29,6 @@ void QueryProfileMatcher::visit(ASTPtr & ast, Data & data)
         return;
     }
 
-    if (auto * t = ast->as<ASTSelectQuery>())
-    {
-        if (t->groupBy())
-            data.has_aggr = true;
-
-        return;
-    }
-
     if (ast->as<ASTSubquery>())
     {
         data.has_subquery = true;

--- a/src/Interpreters/QueryProfileVisitor.h
+++ b/src/Interpreters/QueryProfileVisitor.h
@@ -12,12 +12,11 @@ public:
 
     struct Data
     {
-        bool has_aggr = false;
         bool has_table_join = false;
         bool has_union = false;
         bool has_subquery = false;
 
-        bool done() { return has_aggr && has_table_join && has_union && has_subquery; }
+        bool done() { return has_table_join && has_union && has_subquery; }
     };
 
     static void visit(ASTPtr & ast, Data & data);


### PR DESCRIPTION
…nstead, use native hasAggregation() method of interpreter.

PR checklist:
- Did you run ClangFormat ? Yes
- Did you run CheckStyle ? Yes
- Did you check the comment / log / exception conventions in Engineering code process wiki page ? Yes
- Did you import unnecessary headers ? Yes
- Did you surround `Daisy : starts/ends` for new code in existing ClickHouse code base ? Yes

Please write user-readable short description of the changes:
**Correct the way that SQLAnalalyze api used to determine 'has_aggr'.**