### PR TITLE
fix RestRouterHandler function return type 'const &' error

### DIFF
--- a/src/Server/RestRouterHandlers/RestRouterHandler.h
+++ b/src/Server/RestRouterHandlers/RestRouterHandler.h
@@ -41,7 +41,7 @@ public:
     /// and sends back HTTP `500` to clients
     void execute(HTTPServerRequest & request, HTTPServerResponse & response);
 
-    const String & getPathParameter(const String & name, const String & default_value = "") const
+    String getPathParameter(const String & name, const String & default_value = "") const
     {
         auto iter = path_parameters.find(name);
         if (iter != path_parameters.end())
@@ -61,7 +61,7 @@ public:
 
     void setPathParameter(const String & name, const String & value) { path_parameters[name] = value; }
 
-    const String & getQueryParameter(const String & name, const String & default_value = "") const
+    String getQueryParameter(const String & name, const String & default_value = "") const
     {
         return query_parameters->get(name, default_value);
     }


### PR DESCRIPTION
PR checklist:
- Did you run ClangFormat ?
- Did you run CheckStyle ?
- Did you check the comment / log / exception conventions in Engineering code process wiki page ?
- Did you import unnecessary headers ?
- Did you surround `Daisy : starts/ends` for new code in existing ClickHouse code base ?

Please write user-readable short description of the changes:
**remove RestRouterHandler function return type 'const &' to resolve the temporary variable `default_value` ref error **