### PR TITLE
fix CatalogService empty tables update faild issue

### DIFF
--- a/src/DistributedMetadata/CatalogService.cpp
+++ b/src/DistributedMetadata/CatalogService.cpp
@@ -100,9 +100,13 @@ void CatalogService::doBroadcast()
 
     /// Default max_block_size is 65505 (rows) which shall be bigger enough for a block to contain
     /// all tables on a single node
+
+    /// We include "system.tables" and / or "system.tasks" tables in the resulting block on purpose .
+    /// It is to avoid an empty block if there are no production tables in the system, which will cause
+    /// consistency problem in CatalogService (like the last deleted table does not get deleted from CatalogService)
     String cols = "database, name, engine, uuid, dependencies_table, create_table_query, engine_full, partition_key, sorting_key, primary_key, sampling_key, storage_policy";
     String query = fmt::format(
-        "SELECT {} FROM system.tables WHERE NOT is_temporary AND ((database != 'system') OR (database = 'system' AND name='tasks'))", cols);
+        "SELECT {} FROM system.tables WHERE NOT is_temporary AND ((database != 'system') OR (database = 'system' AND (name = 'tables' OR name = 'tasks')))", cols);
 
     /// FIXME, QueryScope
     /// CurrentThread::attachQueryContext(context);


### PR DESCRIPTION
PR checklist:
- Did you run ClangFormat ?
- Did you run CheckStyle ?
- Did you check the comment / log / exception conventions in Engineering code process wiki page ?
- Did you import unnecessary headers ?
- Did you surround `Daisy : starts/ends` for new code in existing ClickHouse code base ?

Please write user-readable short description of the changes:
to add table `tables` selected, fix empty tables update faild issue in CatalogService