### PR TITLE
fix create table and executeQuery broadcast bug

### DIFF
--- a/src/Server/RestRouterHandlers/ColumnDefinition.cpp
+++ b/src/Server/RestRouterHandlers/ColumnDefinition.cpp
@@ -21,7 +21,11 @@ String getCreateColumnDefination(const Poco::JSON::Object::Ptr & column)
 
     if (column->has("default"))
     {
-        column_definition.push_back(" DEFAULT " + column->get("default").toString());
+        String default_str = "''";
+        if (!column->get("default").toString().empty())
+            default_str = column->get("default").toString();
+
+        column_definition.push_back(" DEFAULT " + default_str);
     }
 
     if (column->has("compression_codec"))

--- a/src/Server/RestRouterHandlers/ColumnDefinition.cpp
+++ b/src/Server/RestRouterHandlers/ColumnDefinition.cpp
@@ -67,7 +67,11 @@ String getUpdateColumnDefination(const Poco::JSON::Object::Ptr & payload, String
 
     if (payload->has("default"))
     {
-        update_segments.push_back(" MODIFY COLUMN " + column_name + " DEFAULT " + payload->get("default").toString());
+        String default_str = "''";
+        if (!payload->get("default").toString().empty())
+            default_str = payload->get("default").toString();
+
+        update_segments.push_back(" MODIFY COLUMN " + column_name + " DEFAULT " + default_str);
     }
 
     if (payload->has("ttl_expression"))


### PR DESCRIPTION
PR checklist:
- Did you run ClangFormat ? yes
- Did you run CheckStyle ? yes
- Did you check the comment / log / exception conventions in Engineering code process wiki page ? yes 
- Did you import unnecessary headers ? no 
- Did you surround `Daisy : starts/ends` for new code in existing ClickHouse code base ? yes

Please write user-readable short description of the changes:
1. fix dafault value is empty when create or update table
2. fix the judgment logic of executeQuery broadcast 
