### PR TITLE
Synchronize table info in storage

### DIFF
--- a/src/DistributedMetadata/CatalogService.cpp
+++ b/src/DistributedMetadata/CatalogService.cpp
@@ -305,17 +305,10 @@ std::pair<CatalogService::TablePtr, StoragePtr> CatalogService::findTableStorage
     return {table_p, nullptr};
 }
 
-void CatalogService::deleteTableStorageByName(const String & database, const String & table)
+inline void CatalogService::deleteTableStorageByName(const String & database, const String & table)
 {
     std::shared_lock storage_guard{storage_rwlock};
-
-    auto storage_iter = storages.find(std::make_pair(database, table));
-    if (storage_iter != storages.end())
-    {
-        auto removed = storages.erase(storage_iter);
-        assert(removed == 1);
-        (void)removed;
-    }
+    storages.erase(std::make_pair(database, table));
 }
 
 CatalogService::TablePtrs CatalogService::findTableByName(const String & database, const String & table) const
@@ -711,10 +704,11 @@ void CatalogService::mergeCatalog(const NodePtr & node, TableContainerPerNode sn
         }
 
         {
-            deleteTableStorageByName(p.second->database, p.second->name);
             std::unique_lock storage_guard{storage_rwlock};
             if (uuid != UUIDHelpers::Nil)
             {
+                deleteTableStorageByName(p.second->database, p.second->name);
+
                 auto removed = indexed_by_id.erase(uuid);
                 (void)removed;
                 assert(removed);

--- a/src/DistributedMetadata/CatalogService.cpp
+++ b/src/DistributedMetadata/CatalogService.cpp
@@ -704,6 +704,7 @@ void CatalogService::mergeCatalog(const NodePtr & node, TableContainerPerNode sn
         }
 
         {
+            /// FIXME, if table definition changed, we will need update the storage inline
             std::unique_lock storage_guard{storage_rwlock};
             if (uuid != UUIDHelpers::Nil)
             {

--- a/src/DistributedMetadata/CatalogService.h
+++ b/src/DistributedMetadata/CatalogService.h
@@ -62,7 +62,7 @@ public:
 
     std::pair<TablePtr, StoragePtr> findTableStorageById(const UUID & uuid) const;
     std::pair<TablePtr, StoragePtr> findTableStorageByName(const String & database, const String & table) const;
-    void deleteTableStorageByName(const String & database, const String & table);
+    inline void deleteTableStorageByName(const String & database, const String & table);
 
     TablePtrs findTableByName(const String & database, const String & table) const;
     TablePtrs findTableByNode(const String & node_identity) const;

--- a/src/DistributedMetadata/CatalogService.h
+++ b/src/DistributedMetadata/CatalogService.h
@@ -62,7 +62,7 @@ public:
 
     std::pair<TablePtr, StoragePtr> findTableStorageById(const UUID & uuid) const;
     std::pair<TablePtr, StoragePtr> findTableStorageByName(const String & database, const String & table) const;
-    inline void deleteTableStorageByName(const String & database, const String & table);
+    void deleteTableStorageByName(const String & database, const String & table);
 
     TablePtrs findTableByName(const String & database, const String & table) const;
     TablePtrs findTableByNode(const String & node_identity) const;

--- a/src/DistributedMetadata/CatalogService.h
+++ b/src/DistributedMetadata/CatalogService.h
@@ -62,6 +62,7 @@ public:
 
     std::pair<TablePtr, StoragePtr> findTableStorageById(const UUID & uuid) const;
     std::pair<TablePtr, StoragePtr> findTableStorageByName(const String & database, const String & table) const;
+    void deleteTableStorageByName(const String & database, const String & table);
 
     TablePtrs findTableByName(const String & database, const String & table) const;
     TablePtrs findTableByNode(const String & node_identity) const;


### PR DESCRIPTION
PR checklist:
- Did you run ClangFormat ? yes
- Did you run CheckStyle ? yes
- Did you check the comment / log / exception conventions in Engineering code process wiki page ? yes
- Did you import unnecessary headers ? no
- Did you surround `Daisy : starts/ends` for new code in existing ClickHouse code base ? yes

Please write user-readable short description of the changes:
1. Synchronize table info in storage when the table is deleted or updated
