### PR TITLE
fix  kafka producer sync append error handling

### DIFF
--- a/src/DistributedWriteAheadLog/KafkaWAL.cpp
+++ b/src/DistributedWriteAheadLog/KafkaWAL.cpp
@@ -331,13 +331,13 @@ AppendResult KafkaWAL::append(const Record & record, const KafkaWALContext & ctx
     {
         /// instead of busy loop, do a timed poll
         rd_kafka_poll(producer_handle.get(), settings->message_delivery_sync_poll_ms);
-        if (dr->offset.load() != -1)
-        {
-            return {.sn = dr->offset.load(), .partition = dr->partition.load()};
-        }
-        else if (dr->err != static_cast<int32_t>(RD_KAFKA_RESP_ERR_NO_ERROR))
+        if (dr->err != static_cast<int32_t>(RD_KAFKA_RESP_ERR_NO_ERROR))
         {
             return handleError(dr->err.load(), record, ctx);
+        }
+        else if (dr->offset.load() != -1)
+        {
+            return {.sn = dr->offset.load(), .partition = dr->partition.load()};
         }
     }
     __builtin_unreachable();

--- a/src/Server/RestRouterHandlers/RestRouterHandler.h
+++ b/src/Server/RestRouterHandlers/RestRouterHandler.h
@@ -68,7 +68,8 @@ public:
 
     bool getQueryParameterBool(const String & name, bool default_value = false) const
     {
-        const auto & val = query_parameters->get(name, "");
+        const auto & default_str = "";
+        const auto & val = query_parameters->get(name, default_str);
         if (val.empty())
         {
             return default_value;


### PR DESCRIPTION
PR checklist:
- Did you run ClangFormat ? yes
- Did you run CheckStyle ? yes
- Did you check the comment / log / exception conventions in Engineering code process wiki page ? yes
- Did you import unnecessary headers ? no 
- Did you surround `Daisy : starts/ends` for new code in existing ClickHouse code base ? yes

Please write user-readable short description of the changes:
1. Fixed kafka producer sync append error handling
2. Fixed getQueryParameter allocator default value error