### PR TITLE
fix getqueryparameter defalult value

### DIFF
--- a/src/Server/RestRouterHandlers/RestRouterHandler.h
+++ b/src/Server/RestRouterHandlers/RestRouterHandler.h
@@ -68,7 +68,7 @@ public:
 
     bool getQueryParameterBool(const String & name, bool default_value = false) const
     {
-        const auto & default_str = "";
+        const String & default_str = "";
         const auto & val = query_parameters->get(name, default_str);
         if (val.empty())
         {


### PR DESCRIPTION
PR checklist:
- Did you run ClangFormat ?
- Did you run CheckStyle ?
- Did you check the comment / log / exception conventions in Engineering code process wiki page ?
- Did you import unnecessary headers ?
- Did you surround `Daisy : starts/ends` for new code in existing ClickHouse code base ?

Please write user-readable short description of the changes:
