### PR TITLE
Block ingestion request when rdkafka queue is full

### DIFF
--- a/src/DistributedWriteAheadLog/KafkaWAL.cpp
+++ b/src/DistributedWriteAheadLog/KafkaWAL.cpp
@@ -414,7 +414,7 @@ int32_t KafkaWAL::doAppend(const Record & record, DeliveryReport * dr, const Kaf
         /// Use builtin partitioner which is consistent hashing to select partition
         /// RD_KAFKA_V_PARTITION(RD_KAFKA_PARTITION_UA),
         /// Return RD_KAFKA_RESP_ERR__QUEUE_FULL if internal queue is full
-        RD_KAFKA_V_MSGFLAGS(RD_KAFKA_MSG_F_FREE),
+        RD_KAFKA_V_MSGFLAGS(RD_KAFKA_MSG_F_FREE | RD_KAFKA_MSG_F_BLOCK),
         /// Message payload and length. Note we didn't copy the data so the ownership
         /// of data will move moved to producev if it succeeds
         RD_KAFKA_V_VALUE(data.data(), data.size()),


### PR DESCRIPTION
PR checklist:
- Did you run ClangFormat ? Yes
- Did you run CheckStyle ? Ye
- Did you check the comment / log / exception conventions in Engineering code process wiki page ? Yes
- Did you import unnecessary headers ? Yes
- Did you surround `Daisy : starts/ends` for new code in existing ClickHouse code base ? Yes

Please write user-readable short description of the changes:
Block ingestion request when rdkafka queue is full