### PR TITLE
fixed memory overflow of escapeName in kafkaWal

### DIFF
--- a/src/DistributedWriteAheadLog/KafkaWALCommon.cpp
+++ b/src/DistributedWriteAheadLog/KafkaWALCommon.cpp
@@ -37,7 +37,7 @@ std::string escapeName(const std::string & s)
         }
         else
         {
-            char out[3] = "_";
+            char out[4] = {"_"};
             writeHexByteUppercase(b, out + 1);
             escaped += out;
         }


### PR DESCRIPTION
PR checklist:
- Did you run ClangFormat ?
- Did you run CheckStyle ?
- Did you check the comment / log / exception conventions in Engineering code process wiki page ?
- Did you import unnecessary headers ?
- Did you surround `Daisy : starts/ends` for new code in existing ClickHouse code base ?

Please write user-readable short description of the changes:
